### PR TITLE
Fix #9: set host user's uid and gid as container user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '2.1'
 services:
   maven:
     image: knowledge-dev
+    user: "${DUID}:${DGID}"
     build:
       context: .
       args:
@@ -14,6 +15,7 @@ services:
       MAVEN_CONFIG: /var/maven/.m2
       https_proxy: ${https_proxy}
       http_proxy: ${http_proxy}
+      HOME: /usr/src/mymaven/
     working_dir: /usr/src/mymaven/
     entrypoint: ''
     volumes:

--- a/launch.sh
+++ b/launch.sh
@@ -3,6 +3,9 @@
 mkdir -p third_party
 git clone --branch v1-dev https://github.com/y-okumura-isp/markedj.git third_party/markedj
 
+export DUID=$(UID)
+export DGID=$(id -g)
+
 docker-compose run --rm maven sh -c "cd third_party/markedj; mvn install -DskipTests=true -Dmaven.javadoc.skip=true"
 docker-compose run --rm maven mvn install -DskipTests=true -Dmaven.javadoc.skip=true -e
 # docker-compose run --rm maven mvn clean test site -e
@@ -10,6 +13,5 @@ docker-compose run --rm maven mvn clean package -e
 
 mkdir target/webapps
 mv target/knowledge.war target/webapps/ROOT.war
-
 docker-compose up --build -d tomcat
 docker-compose logs -f tomcat


### PR DESCRIPTION
Fix #9
Without `$HOME` setting, `npm install` failes when `mkdir /.npm`.
It is the same problem with https://github.com/eirslett/frontend-maven-plugin/issues/846. 