### PR TITLE
Update to jre11, tomcat 9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5-jdk-8-slim
+FROM maven:3.8.4-jdk-11
 
 # install git
 RUN apt-get -y update && apt-get -y install git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - ${KNOWLEDGE_HOME}.m2:/root/.m2
 
   tomcat:
-    image: tomcat:8.5-jre8-alpine
+    image: tomcat:9.0.64-jre11-temurin-focal
     ports:
       - 8080:8080
       - 8009:8009

--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,14 @@
     	  <version>1.1</version>
 	</dependency>
 	<dependency>
+	  <groupId>jakarta.xml.bind</groupId>
+	  <artifactId>jakarta.xml.bind-api</artifactId>
+	  <version>2.3.2</version>
+	</dependency>
+	<dependency>
 	  <groupId>org.glassfish.jaxb</groupId>
 	  <artifactId>jaxb-runtime</artifactId>
-	  <version>2.3.0-b170127.1453</version>
+	  <version>2.3.2</version>
 	</dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>


### PR DESCRIPTION
We need to update pom.xml to prevent the following compilation error.
See https://stackoverflow.com/questions/52502189/java-11-package-javax-xml-bind-does-not-exist.

  org.glassfish.jaxb:jaxb-runtime:jar:2.3.0-b170127.1453
  -> org.glassfish.jaxb:jaxb-core:jar:2.3.0-b170127.1453
  -> javax.xml.bind:jaxb-api:jar:2.3.0-b161121.1438