### PR TITLE
Fix ResourcesTest

### DIFF
--- a/src/test/java/org/support/project/common/config/ResourcesTest.java
+++ b/src/test/java/org/support/project/common/config/ResourcesTest.java
@@ -57,9 +57,9 @@ public class ResourcesTest {
 		assertEquals("aaa is invalid.", str);
 		assertNotEquals("aaaが不正です。", str);
 		
-		//str = Resources.getInstance().getResource("errors.common.notimpl");
-		//logger.info(str);
-		//assertEquals("errors.common.notimpl", str); // 指定のキーにない場合、そのキーをそのまま取得
+		str = Resources.getInstance().getResource("errors.common.notimpl");
+		logger.info(str);
+		assertEquals("errors.common.notimpl", str); // 指定のキーにない場合、そのキーをそのまま取得
 		
 		str = Resources.getInstance(locale).getResource("errors.common.notimpl");
 		logger.info(str);
@@ -71,7 +71,7 @@ public class ResourcesTest {
 		
 		str = Resources.getInstance().getResource("errors.common.notimpl");
 		logger.info(str);
-		assertEquals("errors.common.notimpl", str); // 指定のキーにない場合、そのキーをそのまま取得
+		assertEquals("Not implement.", str); // COMMON_RESOURCE is already read
 	}
 	
 }


### PR DESCRIPTION
We saw the following error at the last
`getResource("errors.common.notimpl");`

```
org.junit.ComparisonFailure: expected:<[errors.common.notimpl]> but
was:<[Not implement.]>
```

As Resources.mapOnLocale is static, the following scenario happens:

(1) Resources.getInstance()
  - APP_RESOURCE is read
(2) Resources.getInstance(locale)
  - APP_RESOURCE is already on mapOnLocale[en]
(3) Resources.getInstance(CommonBaseParameter.COMMON_RESOURCE,
locale):
  - COMMON_RESOURCE is read
  - APP_RESOURCE and COMMON_RESOURCE are on mapOnLocale[en]
(4) Resources.getInstance()
  - APP_RESOURCE and COMMON_RESOURCE are on mapOnLocale[en]